### PR TITLE
gx update and fix code to use new Cid type

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.0.6: QmPcR9Eft4i3XU5DXdnmNY8SWRuFnJms58NKjY1Hso8WiQ
+0.1.0: QmVcoYLHSe31tE18fQznFzEPawkCh9JvWR7zckfwZh1nno

--- a/mfs_test.go
+++ b/mfs_test.go
@@ -196,7 +196,7 @@ func setupRoot(ctx context.Context, t *testing.T) (ipld.DAGService, *Root) {
 	ds := getDagserv(t)
 
 	root := emptyDirNode()
-	rt, err := NewRoot(ctx, ds, root, func(ctx context.Context, c *cid.Cid) error {
+	rt, err := NewRoot(ctx, ds, root, func(ctx context.Context, c cid.Cid) error {
 		fmt.Println("PUBLISHED: ", c)
 		return nil
 	})

--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
   "license": "MIT",
   "name": "go-mfs",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.0.6"
+  "version": "0.1.0"
 }
 

--- a/package.json
+++ b/package.json
@@ -9,33 +9,33 @@
   "gxDependencies": [
     {
       "author": "why",
-      "hash": "QmNr4E8z9bGTztvHJktp7uQaMdx9p3r9Asrq6eYk7iCh4a",
+      "hash": "QmURqt1jB9Yu3X4Tr9WQJf36QGN7vi8mGTzjnX2ij1CJwC",
       "name": "go-merkledag",
-      "version": "1.0.14"
+      "version": "1.1.0"
     },
     {
       "author": "why",
-      "hash": "QmWAfTyD6KEBm7bzqNRBPvqKrZCDtn5PGbs9V1DKfnVK59",
+      "hash": "QmPXzQ9LAFGZjcifFANCQFQiYt5SXgJziGoxUfJULVpHyA",
       "name": "go-unixfs",
-      "version": "1.0.16"
+      "version": "1.1.0"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmZFbDTY9jfSBms2MchvYM9oYRbAF19K7Pby47yDBfpPrb",
+      "hash": "QmPSQnBKM9g7BaUcZCvswUJVscQ1ipjmwxN5PXCjkp9EQ7",
       "name": "go-cid",
-      "version": "0.8.0"
+      "version": "0.9.0"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmX5CsuHyVZeTLxgRSYkgLSDQKb9UjE8xnhQzCEJWWWFsC",
+      "hash": "QmdDXJs4axxefSPgK6Y1QhpJWKuDPnGJiqgq4uncb4rFHL",
       "name": "go-ipld-format",
-      "version": "0.5.8"
+      "version": "0.6.0"
     },
     {
       "author": "why",
-      "hash": "QmNgXoHgXU1HzNb2HEZmRww9fDKE9NfDsvQwWLHiKHpvKM",
+      "hash": "QmRYx6fJzTWFoeTo3qQn64iDrVC154Gy9waQDhvKRr2ND3",
       "name": "go-path",
-      "version": "1.0.14"
+      "version": "1.1.0"
     }
   ],
   "gxVersion": "0.12.1",

--- a/repub_test.go
+++ b/repub_test.go
@@ -18,7 +18,7 @@ func TestRepublisher(t *testing.T) {
 
 	pub := make(chan struct{})
 
-	pf := func(ctx context.Context, c *cid.Cid) error {
+	pf := func(ctx context.Context, c cid.Cid) error {
 		pub <- struct{}{}
 		return nil
 	}
@@ -29,7 +29,7 @@ func TestRepublisher(t *testing.T) {
 	rp := NewRepublisher(ctx, pf, tshort, tlong)
 	go rp.Run()
 
-	rp.Update(nil)
+	rp.Update(cid.Undef)
 
 	// should hit short timeout
 	select {
@@ -42,7 +42,7 @@ func TestRepublisher(t *testing.T) {
 
 	go func() {
 		for {
-			rp.Update(nil)
+			rp.Update(cid.Undef)
 			time.Sleep(time.Millisecond * 10)
 			select {
 			case <-cctx.Done():

--- a/system.go
+++ b/system.go
@@ -58,7 +58,7 @@ type Root struct {
 }
 
 // PubFunc is the function used by the `publish()` method.
-type PubFunc func(context.Context, *cid.Cid) error
+type PubFunc func(context.Context, cid.Cid) error
 
 // NewRoot creates a new Root and starts up a republisher routine for it.
 func NewRoot(parent context.Context, ds ipld.DAGService, node *dag.ProtoNode, pf PubFunc) (*Root, error) {
@@ -182,8 +182,8 @@ type Republisher struct {
 	cancel func()
 
 	lk      sync.Mutex
-	val     *cid.Cid
-	lastpub *cid.Cid
+	val     cid.Cid
+	lastpub cid.Cid
 }
 
 // NewRepublisher creates a new Republisher object to republish the given root
@@ -201,7 +201,7 @@ func NewRepublisher(ctx context.Context, pf PubFunc, tshort, tlong time.Duration
 	}
 }
 
-func (p *Republisher) setVal(c *cid.Cid) {
+func (p *Republisher) setVal(c cid.Cid) {
 	p.lk.Lock()
 	defer p.lk.Unlock()
 	p.val = c
@@ -231,7 +231,7 @@ func (p *Republisher) Close() error {
 // Touch signals that an update has occurred since the last publish.
 // Multiple consecutive touches may extend the time period before
 // the next Publish occurs in order to more efficiently batch updates.
-func (np *Republisher) Update(c *cid.Cid) {
+func (np *Republisher) Update(c cid.Cid) {
 	np.setVal(c)
 	select {
 	case np.Publish <- struct{}{}:


### PR DESCRIPTION
See https://github.com/ipfs/go-cid/pull/71 for additional info.

Depends on:
- [ ] https://github.com/ipfs/go-path/pull/7
- [ ] https://github.com/ipfs/go-unixfs/pull/15

Which Depends on:
- https://github.com/ipfs/go-bitswap/pull/10
- https://github.com/ipfs/go-block-format/pull/14
- https://github.com/ipfs/go-blockservice/pull/5
- https://github.com/ipfs/go-cid/pull/71
- https://github.com/ipfs/go-ipfs-blockstore/pull/15
- https://github.com/ipfs/go-ipfs-blocksutil/pull/2
- https://github.com/ipfs/go-ipfs-chunker/pull/4
- https://github.com/ipfs/go-ipfs-ds-help/pull/6
- https://github.com/ipfs/go-ipfs-exchange-interface/pull/2
- https://github.com/ipfs/go-ipfs-exchange-offline/pull/8
- https://github.com/ipfs/go-ipfs-posinfo/pull/2
- https://github.com/ipfs/go-ipfs-routing/pull/13
- https://github.com/ipfs/go-ipld-cbor/pull/40
- https://github.com/ipfs/go-ipld-format/pull/42
- https://github.com/libp2p/go-libp2p-routing/pull/27
- https://github.com/ipfs/go-merkledag/pull/12
- https://github.com/ipfs/go-verifcid/pull/3

Please approve but do not merge. Depends on locally pinned hashes.