### PR TITLE
gx: update go-libp2p-routing

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.1.1: QmRkrpnhZqDxTxwGCsDbuZMr7uCFZHH6SGfrcjgEQwxF3t
+0.1.2: QmWoqDNUJv3MThSxngVrxRBJ3toUfHdG1XAo6ja2FqRDK9

--- a/package.json
+++ b/package.json
@@ -9,15 +9,15 @@
   "gxDependencies": [
     {
       "author": "why",
-      "hash": "QmXv5mwmQ74r4aiHcNeQ4GAmfB3aWJuqaE4WyDfDfvkgLM",
+      "hash": "QmVB15p7qNVQQGC5RQcAQAovDFaQpRNqorbRwpvdNjHmVC",
       "name": "go-merkledag",
-      "version": "1.1.1"
+      "version": "1.1.2"
     },
     {
       "author": "why",
-      "hash": "QmPL8bYtbACcSFFiSr4s2du7Na382NxRADR8hC7D9FkEA2",
+      "hash": "QmWqiuwk7ZzUFQvfBuQDwxPxyAQtNMxGYwZkjJuF6GgWQk",
       "name": "go-unixfs",
-      "version": "1.1.1"
+      "version": "1.1.2"
     },
     {
       "author": "whyrusleeping",
@@ -33,9 +33,9 @@
     },
     {
       "author": "why",
-      "hash": "QmX7uSbkNz76yNwBhuwYwRbhihLnJqM73VTCjS3UMJud9A",
+      "hash": "Qmc17MNY1xUgiE2nopbi6KATWau9qcGZtdmKKuXvFMVUgc",
       "name": "go-path",
-      "version": "1.1.1"
+      "version": "1.1.2"
     }
   ],
   "gxVersion": "0.12.1",
@@ -43,6 +43,6 @@
   "license": "MIT",
   "name": "go-mfs",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.1.1"
+  "version": "0.1.2"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/libp2p/go-libp2p-kad-dht/pull/199
- https://github.com/ipfs/go-ipfs-routing/pull/14
- https://github.com/libp2p/go-libp2p-routing-helpers/pull/8
- https://github.com/libp2p/go-libp2p-pubsub-router/pull/10
- https://github.com/ipfs/go-bitswap/pull/11
- https://github.com/ipfs/go-blockservice/pull/7
- https://github.com/ipfs/go-merkledag/pull/13
- https://github.com/ipfs/go-path/pull/8
- https://github.com/ipfs/go-unixfs/pull/21


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace