### PR TITLE
fix(mv): correct dst name

### DIFF
--- a/ops_test.go
+++ b/ops_test.go
@@ -1,0 +1,75 @@
+package mfs
+
+import (
+	"context"
+	"testing"
+)
+
+func TestMv(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ds, rt := setupRoot(ctx, t)
+
+	// mkdir dir
+	dirs := []string{"/dir-a", "/dir-b", "/dir-c", "/dir-a/sub-a"}
+	for _, dir := range dirs {
+		err := Mkdir(rt, dir, MkdirOpts{Mkparents: true, Flush: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// create some files
+	nd := getRandFile(t, ds, 1000)
+	err := rt.GetDirectory().AddChild("file-a", nd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = rt.GetDirectory().AddChild("file-b", nd)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// mv parent dir to child dir
+	err = Mv(rt, "/dir-a", "/dir-a/sub-a")
+	if err != errMvParentDir {
+		t.Fatal(err)
+	}
+
+	err = Mv(rt, "/", "/dir-a")
+	if err != errMvParentDir {
+		t.Fatal(err)
+	}
+
+	// src path ends with '/' is not a directory
+	err = Mv(rt, "/file-a/", "/dir-a")
+	if err != errInvalidDirPath {
+		t.Fatal(err)
+	}
+
+	err = Mv(rt, "/dir-b", "/file-a")
+	if err != errMvDirToFile {
+		t.Fatal(err)
+	}
+
+	// fix #5346
+	err = Mv(rt, "/file-a", "/dir-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = Lookup(rt, "/dir-a/file-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = Mv(rt, "/file-b", "/dir-a/")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = Lookup(rt, "/dir-a/file-b")
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Fix: https://github.com/ipfs/go-mfs/issues/18
Refer to: https://github.com/ipfs/go-ipfs/issues/5346

From https://github.com/ipfs/go-ipfs/pull/5361#discussion_r209113416 the rules should be:

```
if src.Type == dir:
     if dest.Type == dir: 
            if dest.Contains(src):
                if dest.Empty(): unlink
                else: return an error
            move src to dest/
     else if dest.Type == file: case a error
else if src.Type == file:
     if dest.Type == file: replace(src, dest)
     else if desc.Type == directory: 
              if desc.Contains(src):
                  if desc.Type == dir and not desc.Empty():
                      return an error
                  unlink src from desc
              move src to desc/
```
