### PR TITLE
gx: update to use extracted go-ipfs-files

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.1.9: Qmbs19iFfAxmYfjrHib6G2eJCczoNZ3GQED6CDxmhc2dn2
+0.1.10: QmP2sH3hdhseUsoNBhAZSCkeUvTGgYXxvZjSB2s7yg4aoD

--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
   "license": "MIT",
   "name": "go-mfs",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.1.9"
+  "version": "0.1.10"
 }
 

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     },
     {
       "author": "why",
-      "hash": "QmRX6WZhMinQrQhyuwaqNHYQtNPhtBwzxKFySzNMaJmW9v",
+      "hash": "QmZMVjyWaNCo3Ec44Ce2BcboNuGiQZiJdwW2D3pzwsJdRd",
       "name": "go-unixfs",
-      "version": "1.1.9"
+      "version": "1.1.10"
     },
     {
       "author": "whyrusleeping",


### PR DESCRIPTION
Depends on https://github.com/ipfs/go-unixfs/pull/36