### PR TITLE
Various refactorings

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ This repository contains many files, all belonging to the root `mfs` package.
 * `dir.go`: MFS `Directory`.
 * `fd.go`: `FileDescriptor` used to operate on `File`s.
 * `ops.go`: Functions that do not belong to either `File` nor `Directory` (although they mostly operate on them) that contain common operations to the MFS, e.g., find, move, add a file, make a directory.
-* `system.go`: Made up of two parts, the MFS `Root` and the `Republisher`.
+* `root.go`: MFS `Root` (a `Directory` with republishing support).
+* `repub.go`: `Republisher`.
 * `mfs_test.go`: General tests (needs a [revision](https://github.com/ipfs/go-mfs/issues/9)).
 * `repub_test.go`: Republisher-specific tests (contains only the `TestRepublisher` function).
 

--- a/dir.go
+++ b/dir.go
@@ -47,7 +47,7 @@ type Directory struct {
 //
 // You probably don't want to call this directly. Instead, construct a new root
 // using NewRoot.
-func NewDirectory(ctx context.Context, name string, node ipld.Node, parent mutableParent, dserv ipld.DAGService) (*Directory, error) {
+func NewDirectory(ctx context.Context, name string, node ipld.Node, parent parent, dserv ipld.DAGService) (*Directory, error) {
 	db, err := uio.NewDirectoryFromNode(dserv, node)
 	if err != nil {
 		return nil, err
@@ -76,7 +76,7 @@ func (d *Directory) SetCidBuilder(b cid.Builder) {
 	d.unixfsDir.SetCidBuilder(b)
 }
 
-// This method implements the `mutableParent` interface. It first updates
+// This method implements the `parent` interface. It first updates
 // the child entry in the underlying UnixFS directory and then if `fullSync`
 // is set it saves the new content through the internal DAG service. Then,
 // also if `fullSync` is set, it propagates the update to its parent (through

--- a/dir.go
+++ b/dir.go
@@ -77,14 +77,11 @@ func (d *Directory) SetCidBuilder(b cid.Builder) {
 }
 
 // This method implements the `parent` interface. It first updates
-// the child entry in the underlying UnixFS directory and then if `fullSync`
-// is set it saves the new content through the internal DAG service. Then,
-// also if `fullSync` is set, it propagates the update to its parent (through
-// this same interface) with the new node already updated with the new entry.
-// So, `fullSync` entails operations at two different layers:
-//   1. DAG: save the newly created directory node with the updated entry.
-//   2. MFS: propagate the update upwards repeating the whole process in the
-//           parent.
+// the child entry in the underlying UnixFS directory and then, if `fullSync`
+// is set, it:
+//   1. DAG: saves the newly created directory node with the updated entry.
+//   2. MFS: propagates the update upwards (through this same interface)
+//           repeating the whole process in the parent.
 func (d *Directory) updateChildEntry(c child, fullSync bool) error {
 
 	// There's a local flush (`closeChildUpdate`) and a propagated flush (`updateChildEntry`).

--- a/dir.go
+++ b/dir.go
@@ -160,7 +160,7 @@ func (d *Directory) flushCurrentNode() (*dag.ProtoNode, error) {
 
 // Update child entry in the underlying UnixFS directory.
 func (d *Directory) updateChild(c child) error {
-	err := d.AddUnixFSChild(c)
+	err := d.addUnixFSChild(c)
 	if err != nil {
 		return err
 	}
@@ -345,7 +345,7 @@ func (d *Directory) Mkdir(name string) (*Directory, error) {
 		return nil, err
 	}
 
-	err = d.AddUnixFSChild(child{name, ndir})
+	err = d.addUnixFSChild(child{name, ndir})
 	if err != nil {
 		return nil, err
 	}
@@ -392,7 +392,7 @@ func (d *Directory) AddChild(name string, nd ipld.Node) error {
 		return err
 	}
 
-	err = d.AddUnixFSChild(child{name, nd})
+	err = d.addUnixFSChild(child{name, nd})
 	if err != nil {
 		return err
 	}
@@ -401,9 +401,9 @@ func (d *Directory) AddChild(name string, nd ipld.Node) error {
 	return nil
 }
 
-// AddUnixFSChild adds a child to the inner UnixFS directory
+// addUnixFSChild adds a child to the inner UnixFS directory
 // and transitions to a HAMT implementation if needed.
-func (d *Directory) AddUnixFSChild(c child) error {
+func (d *Directory) addUnixFSChild(c child) error {
 	if uio.UseHAMTSharding {
 		// If the directory HAMT implementation is being used and this
 		// directory is actually a basic implementation switch it to HAMT.

--- a/fd.go
+++ b/fd.go
@@ -149,7 +149,7 @@ func (fi *fileDescriptor) flushUp(fullsync bool) error {
 	fi.inode.nodelk.Unlock()
 	// TODO: Maybe all this logic should happen in `File`.
 
-	return parent.closeChild(child{name, nd}, fullsync)
+	return parent.updateChildEntry(child{name, nd}, fullsync)
 }
 
 // Seek implements io.Seeker

--- a/fd.go
+++ b/fd.go
@@ -149,7 +149,7 @@ func (fi *fileDescriptor) flushUp(fullsync bool) error {
 	fi.inode.nodelk.Unlock()
 	// TODO: Maybe all this logic should happen in `File`.
 
-	return parent.closeChild(name, nd, fullsync)
+	return parent.closeChild(child{name, nd}, fullsync)
 }
 
 // Seek implements io.Seeker

--- a/file.go
+++ b/file.go
@@ -36,7 +36,7 @@ type File struct {
 
 // NewFile returns a NewFile object with the given parameters.  If the
 // Cid version is non-zero RawLeaves will be enabled.
-func NewFile(name string, node ipld.Node, parent childCloser, dserv ipld.DAGService) (*File, error) {
+func NewFile(name string, node ipld.Node, parent mutableParent, dserv ipld.DAGService) (*File, error) {
 	fi := &File{
 		inode: inode{
 			name:       name,

--- a/file.go
+++ b/file.go
@@ -36,7 +36,7 @@ type File struct {
 
 // NewFile returns a NewFile object with the given parameters.  If the
 // Cid version is non-zero RawLeaves will be enabled.
-func NewFile(name string, node ipld.Node, parent mutableParent, dserv ipld.DAGService) (*File, error) {
+func NewFile(name string, node ipld.Node, parent parent, dserv ipld.DAGService) (*File, error) {
 	fi := &File{
 		inode: inode{
 			name:       name,

--- a/inode.go
+++ b/inode.go
@@ -13,7 +13,7 @@ type inode struct {
 	name string
 
 	// parent directory of this `inode` (which may be the `Root`).
-	parent mutableParent
+	parent parent
 
 	// dagService used to store modifications made to the contents
 	// of the file or directory the `inode` belongs to.

--- a/inode.go
+++ b/inode.go
@@ -13,7 +13,7 @@ type inode struct {
 	name string
 
 	// parent directory of this `inode` (which may be the `Root`).
-	parent childCloser
+	parent mutableParent
 
 	// dagService used to store modifications made to the contents
 	// of the file or directory the `inode` belongs to.

--- a/mfs_test.go
+++ b/mfs_test.go
@@ -419,12 +419,6 @@ func TestMfsFile(t *testing.T) {
 		t.Fatal("didnt write correct number of bytes")
 	}
 
-	// sync file
-	err = wfd.Sync()
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	// make sure size hasnt changed
 	size, err = wfd.Size()
 	if err != nil {

--- a/repub.go
+++ b/repub.go
@@ -1,0 +1,135 @@
+package mfs
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	cid "github.com/ipfs/go-cid"
+)
+
+// PubFunc is the function used by the `publish()` method.
+type PubFunc func(context.Context, cid.Cid) error
+
+// Republisher manages when to publish a given entry.
+type Republisher struct {
+	TimeoutLong  time.Duration
+	TimeoutShort time.Duration
+	Publish      chan struct{}
+	pubfunc      PubFunc
+	pubnowch     chan chan struct{}
+
+	ctx    context.Context
+	cancel func()
+
+	lk      sync.Mutex
+	val     cid.Cid
+	lastpub cid.Cid
+}
+
+// NewRepublisher creates a new Republisher object to republish the given root
+// using the given short and long time intervals.
+func NewRepublisher(ctx context.Context, pf PubFunc, tshort, tlong time.Duration) *Republisher {
+	ctx, cancel := context.WithCancel(ctx)
+	return &Republisher{
+		TimeoutShort: tshort,
+		TimeoutLong:  tlong,
+		Publish:      make(chan struct{}, 1),
+		pubfunc:      pf,
+		pubnowch:     make(chan chan struct{}),
+		ctx:          ctx,
+		cancel:       cancel,
+	}
+}
+
+func (p *Republisher) setVal(c cid.Cid) {
+	p.lk.Lock()
+	defer p.lk.Unlock()
+	p.val = c
+}
+
+// WaitPub Returns immediately if `lastpub` value is consistent with the
+// current value `val`, else will block until `val` has been published.
+func (p *Republisher) WaitPub() {
+	p.lk.Lock()
+	consistent := p.lastpub == p.val
+	p.lk.Unlock()
+	if consistent {
+		return
+	}
+
+	wait := make(chan struct{})
+	p.pubnowch <- wait
+	<-wait
+}
+
+func (p *Republisher) Close() error {
+	err := p.publish(p.ctx)
+	p.cancel()
+	return err
+}
+
+// Touch signals that an update has occurred since the last publish.
+// Multiple consecutive touches may extend the time period before
+// the next Publish occurs in order to more efficiently batch updates.
+func (np *Republisher) Update(c cid.Cid) {
+	np.setVal(c)
+	select {
+	case np.Publish <- struct{}{}:
+	default:
+	}
+}
+
+// Run is the main republisher loop.
+// TODO: Document according to:
+// https://github.com/ipfs/go-ipfs/issues/5092#issuecomment-398524255.
+func (np *Republisher) Run() {
+	for {
+		select {
+		case <-np.Publish:
+			quick := time.After(np.TimeoutShort)
+			longer := time.After(np.TimeoutLong)
+
+		wait:
+			var pubnowresp chan struct{}
+
+			select {
+			case <-np.ctx.Done():
+				return
+			case <-np.Publish:
+				quick = time.After(np.TimeoutShort)
+				goto wait
+			case <-quick:
+			case <-longer:
+			case pubnowresp = <-np.pubnowch:
+			}
+
+			err := np.publish(np.ctx)
+			if pubnowresp != nil {
+				pubnowresp <- struct{}{}
+			}
+			if err != nil {
+				log.Errorf("republishRoot error: %s", err)
+			}
+
+		case <-np.ctx.Done():
+			return
+		}
+	}
+}
+
+// publish calls the `PubFunc`.
+func (np *Republisher) publish(ctx context.Context) error {
+	np.lk.Lock()
+	topub := np.val
+	np.lk.Unlock()
+
+	err := np.pubfunc(ctx, topub)
+	if err != nil {
+		return err
+	}
+	np.lk.Lock()
+	np.lastpub = topub
+	np.lk.Unlock()
+	return nil
+}

--- a/root.go
+++ b/root.go
@@ -61,8 +61,11 @@ const (
 	TDir
 )
 
-// FSNode represents any node (directory, or file) in the MFS filesystem.
-// Not to be confused with the `unixfs.FSNode`.
+// FSNode abstracts the `Directory` and `File` structures, it represents
+// any child node in the MFS (i.e., all the nodes besides the `Root`). It
+// is the counterpart of the `mutableParent` interface which represents any
+// parent node in the MFS (`Root` and `Directory`).
+// (Not to be confused with the `unixfs.FSNode`.)
 type FSNode interface {
 	GetNode() (ipld.Node, error)
 	Flush() error
@@ -167,11 +170,8 @@ func (kr *Root) FlushMemFree(ctx context.Context) error {
 	dir.lock.Lock()
 	defer dir.lock.Unlock()
 
-	for name := range dir.files {
-		delete(dir.files, name)
-	}
-	for name := range dir.childDirs {
-		delete(dir.childDirs, name)
+	for name := range dir.entriesCache {
+		delete(dir.entriesCache, name)
 	}
 	// TODO: Can't we just create new maps?
 

--- a/root.go
+++ b/root.go
@@ -43,7 +43,7 @@ type child struct {
 // distinguished here, one at the DAG level (when I store the modified
 // nodes in the DAG service) and one in the UnixFS/MFS level (when I modify
 // the entry/link of the directory that pointed to the modified node).
-type mutableParent interface {
+type parent interface {
 	// Method called by a child to its parent to signal to update the content
 	// pointed to in the entry by that child's name. The child sends as
 	// arguments its own information (under the `child` structure) and a flag
@@ -63,7 +63,7 @@ const (
 
 // FSNode abstracts the `Directory` and `File` structures, it represents
 // any child node in the MFS (i.e., all the nodes besides the `Root`). It
-// is the counterpart of the `mutableParent` interface which represents any
+// is the counterpart of the `parent` interface which represents any
 // parent node in the MFS (`Root` and `Directory`).
 // (Not to be confused with the `unixfs.FSNode`.)
 type FSNode interface {
@@ -182,8 +182,8 @@ func (kr *Root) FlushMemFree(ctx context.Context) error {
 	return nil
 }
 
-// updateChildEntry implements the mutableParent interface, and signals to the publisher that
-// there are changes ready to be published.
+// updateChildEntry implements the `parent` interface, and signals
+// to the publisher that there are changes ready to be published.
 // This is the only thing that separates a `Root` from a `Directory`.
 // TODO: Evaluate merging both.
 // TODO: The `sync` argument isn't used here (we've already reached

--- a/root.go
+++ b/root.go
@@ -97,7 +97,11 @@ func NewRoot(parent context.Context, ds ipld.DAGService, node *dag.ProtoNode, pf
 	var repub *Republisher
 	if pf != nil {
 		repub = NewRepublisher(parent, pf, time.Millisecond*300, time.Second*3)
-		repub.setVal(node.Cid())
+
+		repub.valueToPublish = node.Cid()
+		// No need to take the lock here since we just created
+		// the `Republisher` and no one has access to it yet.
+
 		go repub.Run()
 	}
 

--- a/root.go
+++ b/root.go
@@ -1,26 +1,17 @@
 // package mfs implements an in memory model of a mutable IPFS filesystem.
-// TODO: Develop on this line (and move it elsewhere), delete the rest.
-//
-// It consists of four main structs:
-// 1) The Filesystem
-//        The filesystem serves as a container and entry point for various mfs filesystems
-// 2) Root
-//        Root represents an individual filesystem mounted within the mfs system as a whole
-// 3) Directories
-// 4) Files
+// TODO: Develop on this line (and move it to `doc.go`).
+
 package mfs
 
 import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 	"time"
 
 	dag "github.com/ipfs/go-merkledag"
 	ft "github.com/ipfs/go-unixfs"
 
-	cid "github.com/ipfs/go-cid"
 	ipld "github.com/ipfs/go-ipld-format"
 	logging "github.com/ipfs/go-log"
 )
@@ -219,133 +210,5 @@ func (kr *Root) Close() error {
 		return kr.repub.Close()
 	}
 
-	return nil
-}
-
-// TODO: Separate the remaining code in another file: `repub.go`.
-
-// PubFunc is the function used by the `publish()` method.
-type PubFunc func(context.Context, cid.Cid) error
-
-// Republisher manages when to publish a given entry.
-type Republisher struct {
-	TimeoutLong  time.Duration
-	TimeoutShort time.Duration
-	Publish      chan struct{}
-	pubfunc      PubFunc
-	pubnowch     chan chan struct{}
-
-	ctx    context.Context
-	cancel func()
-
-	lk      sync.Mutex
-	val     cid.Cid
-	lastpub cid.Cid
-}
-
-// NewRepublisher creates a new Republisher object to republish the given root
-// using the given short and long time intervals.
-func NewRepublisher(ctx context.Context, pf PubFunc, tshort, tlong time.Duration) *Republisher {
-	ctx, cancel := context.WithCancel(ctx)
-	return &Republisher{
-		TimeoutShort: tshort,
-		TimeoutLong:  tlong,
-		Publish:      make(chan struct{}, 1),
-		pubfunc:      pf,
-		pubnowch:     make(chan chan struct{}),
-		ctx:          ctx,
-		cancel:       cancel,
-	}
-}
-
-func (p *Republisher) setVal(c cid.Cid) {
-	p.lk.Lock()
-	defer p.lk.Unlock()
-	p.val = c
-}
-
-// WaitPub Returns immediately if `lastpub` value is consistent with the
-// current value `val`, else will block until `val` has been published.
-func (p *Republisher) WaitPub() {
-	p.lk.Lock()
-	consistent := p.lastpub == p.val
-	p.lk.Unlock()
-	if consistent {
-		return
-	}
-
-	wait := make(chan struct{})
-	p.pubnowch <- wait
-	<-wait
-}
-
-func (p *Republisher) Close() error {
-	err := p.publish(p.ctx)
-	p.cancel()
-	return err
-}
-
-// Touch signals that an update has occurred since the last publish.
-// Multiple consecutive touches may extend the time period before
-// the next Publish occurs in order to more efficiently batch updates.
-func (np *Republisher) Update(c cid.Cid) {
-	np.setVal(c)
-	select {
-	case np.Publish <- struct{}{}:
-	default:
-	}
-}
-
-// Run is the main republisher loop.
-// TODO: Document according to:
-// https://github.com/ipfs/go-ipfs/issues/5092#issuecomment-398524255.
-func (np *Republisher) Run() {
-	for {
-		select {
-		case <-np.Publish:
-			quick := time.After(np.TimeoutShort)
-			longer := time.After(np.TimeoutLong)
-
-		wait:
-			var pubnowresp chan struct{}
-
-			select {
-			case <-np.ctx.Done():
-				return
-			case <-np.Publish:
-				quick = time.After(np.TimeoutShort)
-				goto wait
-			case <-quick:
-			case <-longer:
-			case pubnowresp = <-np.pubnowch:
-			}
-
-			err := np.publish(np.ctx)
-			if pubnowresp != nil {
-				pubnowresp <- struct{}{}
-			}
-			if err != nil {
-				log.Errorf("republishRoot error: %s", err)
-			}
-
-		case <-np.ctx.Done():
-			return
-		}
-	}
-}
-
-// publish calls the `PubFunc`.
-func (np *Republisher) publish(ctx context.Context) error {
-	np.lk.Lock()
-	topub := np.val
-	np.lk.Unlock()
-
-	err := np.pubfunc(ctx, topub)
-	if err != nil {
-		return err
-	}
-	np.lk.Lock()
-	np.lastpub = topub
-	np.lk.Unlock()
 	return nil
 }

--- a/system.go
+++ b/system.go
@@ -33,6 +33,15 @@ var log = logging.Logger("mfs")
 // TODO: Remove if not used.
 var ErrIsDirectory = errors.New("error: is a directory")
 
+// The information that an MFS `Directory` has about its children
+// when updating one of its entries: when a child mutates it signals
+// its parent directory to update its entry (under `Name`) with the
+// new content (in `Node`).
+type child struct {
+	Name string
+	Node ipld.Node
+}
+
 // TODO: Rename (avoid "close" terminology, if anything
 // we are persisting/flushing changes).
 // This is always a directory (since we are referring to the parent),

--- a/system.go
+++ b/system.go
@@ -52,7 +52,7 @@ type child struct {
 // nodes in the DAG service) and one in the UnixFS/MFS level (when I modify
 // the entry/link of the directory that pointed to the modified node).
 type childCloser interface {
-	closeChild(string, ipld.Node, bool) error
+	closeChild(child, bool) error
 }
 
 type NodeType int
@@ -186,14 +186,14 @@ func (kr *Root) FlushMemFree(ctx context.Context) error {
 // TODO: The `sync` argument isn't used here (we've already reached
 // the top), document it and maybe make it an anonymous variable (if
 // that's possible).
-func (kr *Root) closeChild(name string, nd ipld.Node, sync bool) error {
-	err := kr.GetDirectory().dagService.Add(context.TODO(), nd)
+func (kr *Root) closeChild(c child, sync bool) error {
+	err := kr.GetDirectory().dagService.Add(context.TODO(), c.Node)
 	if err != nil {
 		return err
 	}
 
 	if kr.repub != nil {
-		kr.repub.Update(nd.Cid())
+		kr.repub.Update(c.Node.Cid())
 	}
 	return nil
 }


### PR DESCRIPTION
This PR contains a series of commits with diverse MFS code refactorings. The commits are loosely tied together here to make it easier to review and merge. This PR then should be reviewed on a commit-by-commit basis in chronological order.

This PR breaks the current API (which is something expected in the context of the [milestone to review the MFS API](https://github.com/ipfs/go-mfs/milestone/1)) but only in evident ways, e.g., renaming/removing functions, it doesn't change the current behavior (those kind of changes will be discussed in separate issues/PRs).