### PR TITLE
use RW lock for the `File`'s lock

### DIFF
--- a/fd.go
+++ b/fd.go
@@ -140,13 +140,13 @@ func (fi *fileDescriptor) flushUp(fullsync bool) error {
 		return err
 	}
 
-	fi.inode.nodelk.Lock()
+	fi.inode.nodeLock.Lock()
 	fi.inode.node = nd
 	// TODO: Create a `SetNode` method.
 	name := fi.inode.name
 	parent := fi.inode.parent
 	// TODO: Can the parent be modified? Do we need to do this inside the lock?
-	fi.inode.nodelk.Unlock()
+	fi.inode.nodeLock.Unlock()
 	// TODO: Maybe all this logic should happen in `File`.
 
 	return parent.closeChild(name, nd, fullsync)


### PR DESCRIPTION
Based on https://github.com/ipfs/go-ipfs/pull/4517/commits/feafd115c7d0a228dad26279b2e999560c39d721 with the difference that in `flushUp` we keep the `Lock()` call effectively taking the lock for writing since we're replacing the current node's value (@Stebalien please validate this).

(Related to https://github.com/ipfs/go-mfs/issues/32.)