### PR TITLE
[WIP] Invalidate `Unlink`ed `FSNode`s from the cache

### DIFF
--- a/fd.go
+++ b/fd.go
@@ -150,6 +150,12 @@ func (fi *fileDescriptor) flushUp(fullSync bool) error {
 	fi.inode.nodeLock.Unlock()
 	// TODO: Maybe all this logic should happen in `File`.
 
+	if parent == nil {
+		// TODO: This file has already been unlinked from the MFS,
+		// can not propagate any update upwards.
+		return nil
+	}
+
 	if fullSync {
 		return parent.updateChildEntry(child{name, nd})
 	}

--- a/file.go
+++ b/file.go
@@ -175,3 +175,7 @@ func (fi *File) Sync() error {
 func (fi *File) Type() NodeType {
 	return TFile
 }
+
+func (d *File) RemoveParent() {
+	d.inode.parent = nil
+}

--- a/root.go
+++ b/root.go
@@ -69,6 +69,7 @@ type FSNode interface {
 	GetNode() (ipld.Node, error)
 	Flush() error
 	Type() NodeType
+	RemoveParent()
 }
 
 // IsDir checks whether the FSNode is dir type


### PR DESCRIPTION
Inspired by https://github.com/ipfs/go-mfs/pull/48#issuecomment-451692299.

Provisional (informal) description:

1. The only place that should modify the internal bookkeeping of issued `FSNode`s (e.g., when calling `Child`), alias the "cache", to remove entries should be `Unlink`.

2. If you need to lower the memory usage because you requested too many nodes (a.k.a. listed the entire MFS) remove the entire MFS reference (I'm not sure this is a perfect guarantee, we don't know when all the `FSNode`s are reclaimed by GC).

3. When removed from our internal bookkeeping, nullify the `FSNode` structure issued, this is implemented here by setting the `parent` reference to `nil` to make sure it doesn't have access to upper layers to propagate its changes. (This is just a proposed solution, we could add an explicit `unlinked` field or similar).
