### PR TITLE
fix over-wait in WaitPub

### DIFF
--- a/ops.go
+++ b/ops.go
@@ -1,6 +1,7 @@
 package mfs
 
 import (
+	"context"
 	"fmt"
 	"os"
 	gopath "path"
@@ -235,6 +236,6 @@ func FlushPath(rt *Root, pth string) error {
 		return err
 	}
 
-	rt.repub.WaitPub()
+	rt.repub.WaitPub(context.TODO())
 	return nil
 }

--- a/repub_test.go
+++ b/repub_test.go
@@ -23,13 +23,16 @@ func TestRepublisher(t *testing.T) {
 		return nil
 	}
 
+	testCid1, _ := cid.Parse("QmeomffUNfmQy76CQGy9NdmqEnnHU9soCexBnGU3ezPHVH")
+	testCid2, _ := cid.Parse("QmeomffUNfmQy76CQGy9NdmqEnnHU9soCexBnGU3ezPHVX")
+
 	tshort := time.Millisecond * 50
 	tlong := time.Second / 2
 
 	rp := NewRepublisher(ctx, pf, tshort, tlong)
-	go rp.Run()
+	go rp.Run(cid.Undef)
 
-	rp.Update(cid.Undef)
+	rp.Update(testCid1)
 
 	// should hit short timeout
 	select {
@@ -42,7 +45,7 @@ func TestRepublisher(t *testing.T) {
 
 	go func() {
 		for {
-			rp.Update(cid.Undef)
+			rp.Update(testCid2)
 			time.Sleep(time.Millisecond * 10)
 			select {
 			case <-cctx.Done():
@@ -65,13 +68,8 @@ func TestRepublisher(t *testing.T) {
 
 	cancel()
 
-	go func() {
-		err := rp.Close()
-		if err != nil {
-			t.Fatal(err)
-		}
-	}()
-
-	// final pub from closing
-	<-pub
+	err := rp.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
 }

--- a/root.go
+++ b/root.go
@@ -99,11 +99,10 @@ func NewRoot(parent context.Context, ds ipld.DAGService, node *dag.ProtoNode, pf
 	if pf != nil {
 		repub = NewRepublisher(parent, pf, time.Millisecond*300, time.Second*3)
 
-		repub.valueToPublish = node.Cid()
 		// No need to take the lock here since we just created
 		// the `Republisher` and no one has access to it yet.
 
-		go repub.Run()
+		go repub.Run(node.Cid())
 	}
 
 	root := &Root{


### PR DESCRIPTION
Before, WaitPub could wait forever if a value was published at the same time as the call to WaitPub.

This patch also avoids republishing the same value multiple times and allows setting an initial value without reaching in and modifying internal state.

fixes #38