### PR TITLE
repub: fix typo in comparison

### DIFF
--- a/repub.go
+++ b/repub.go
@@ -143,7 +143,7 @@ func (rp *Republisher) Run(lastPublished cid.Cid) {
 			}
 
 			// Avoid publishing duplicate values
-			if !lastPublished.Equals(toPublish) {
+			if lastPublished.Equals(toPublish) {
 				toPublish = cid.Undef
 			}
 		case <-quick.C:


### PR DESCRIPTION
We only unset `toPublish` if it was a repeated value.