### PR TITLE
Return node from FlushPath

### DIFF
--- a/mfs_test.go
+++ b/mfs_test.go
@@ -817,19 +817,23 @@ func TestFlushing(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := FlushPath(ctx, rt, "/a/b/c/TEST"); err != nil {
+	nd, err := FlushPath(ctx, rt, "/a/b/c/TEST")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if nd.Cid().String() != "QmYi7wrRFKVCcTB56A6Pep2j31Q5mHfmmu21RzHXu25RVR" {
+		t.Fatalf("unexpected node from FlushPath: %s", nd.Cid())
+	}
+
+	if _, err := FlushPath(ctx, rt, "/a/b/d/TEST"); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := FlushPath(ctx, rt, "/a/b/d/TEST"); err != nil {
+	if _, err := FlushPath(ctx, rt, "/a/b/e/TEST"); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := FlushPath(ctx, rt, "/a/b/e/TEST"); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := FlushPath(ctx, rt, "/FILE"); err != nil {
+	if _, err := FlushPath(ctx, rt, "/FILE"); err != nil {
 		t.Fatal(err)
 	}
 

--- a/ops.go
+++ b/ops.go
@@ -226,17 +226,17 @@ func DirLookup(d *Directory, pth string) (FSNode, error) {
 
 // TODO: Document this function and link its functionality
 // with the republisher.
-func FlushPath(ctx context.Context, rt *Root, pth string) error {
+func FlushPath(ctx context.Context, rt *Root, pth string) (ipld.Node, error) {
 	nd, err := Lookup(rt, pth)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	err = nd.Flush()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	rt.repub.WaitPub(ctx)
-	return nil
+	return nd.GetNode()
 }


### PR DESCRIPTION
So we can tell what exactly was flushed - https://github.com/ipfs/interface-go-ipfs-core/pull/19#discussion_r266574610