### PR TITLE
Fix incorrect mutex unlock call in File.Open

### DIFF
--- a/file.go
+++ b/file.go
@@ -64,7 +64,7 @@ func (fi *File) Open(flags Flags) (_ FileDescriptor, _retErr error) {
 		fi.desclock.RLock()
 		defer func() {
 			if _retErr != nil {
-				fi.desclock.Unlock()
+				fi.desclock.RUnlock()
 			}
 		}()
 	} else {


### PR DESCRIPTION
A `File`'s read mutex is locked when entering the call to open with read only flags, but the mutex's write lock is being requested to release when/if defer sees an error in the call to `File.Open`.